### PR TITLE
enable logging run2 for pandas groupby q3

### DIFF
--- a/pandas/groupby-pandas.py
+++ b/pandas/groupby-pandas.py
@@ -120,7 +120,7 @@ m = memory_usage()
 t_start = timeit.default_timer()
 chk = [ans['v1'].sum(), ans['v3'].sum()]
 chkt = timeit.default_timer() - t_start
-# write_log(task=task, data=data_name, in_rows=x.shape[0], question=question, out_rows=ans.shape[0], out_cols=ans.shape[1], solution=solution, version=ver, git=git, fun=fun, run=2, time_sec=t, mem_gb=m, cache=cache, chk=make_chk(chk), chk_time_sec=chkt, on_disk=on_disk)
+write_log(task=task, data=data_name, in_rows=x.shape[0], question=question, out_rows=ans.shape[0], out_cols=ans.shape[1], solution=solution, version=ver, git=git, fun=fun, run=2, time_sec=t, mem_gb=m, cache=cache, chk=make_chk(chk), chk_time_sec=chkt, on_disk=on_disk)
 print(ans.head(3), flush=True)
 print(ans.tail(3), flush=True)
 del ans


### PR DESCRIPTION
Not sure why it was commented out in the first place.

Probably a mistake in https://github.com/duckdblabs/db-benchmark/commit/49a0552967141266a0416beb6c5ba332f7a7ee3b