### PR TITLE
CI when no errors prints last line of scripts output

### DIFF
--- a/_utils/validate_no_errors.sh
+++ b/_utils/validate_no_errors.sh
@@ -1,6 +1,7 @@
 if [ $(grep -i "error" out/*.err | wc -l) = 0 ]
 then
-	# no true errors found
+	# no true errors found, print last line of each output script
+        tail -n 1 out/*.out
 	exit 0;
 fi
 # errors found


### PR DESCRIPTION
This gives something like
```
$ tail -n 1 out/*.out
==> out/run_datatable_rollfun_R1_1e6_NA_0_1.out <==
rolling finished, took 1s

==> out/run_datatable_rollfun_R1_1e8_NA_0_1.out <==
loading dataset R1_1e8_NA_0_1

==> out/run_dplyr_rollfun_R1_1e6_NA_0_1.out <==
rolling finished, took 4s

...
```
which is useful.
It can happen that script got stuck/terminated but process did not wrote an "error" word to console, then it would not be detected.
This way user can easily see if script finished completely without needing to download and unzip artifacts. I check CI logs from my mobile, and downloading+unziping and looking for that info is not very convenient. After this change I just browse GH checks page and can see it.