### PR TITLE
Improve pandas groupby corr benchmark

### DIFF
--- a/_benchplot/benchplot-dict.R
+++ b/_benchplot/benchplot-dict.R
@@ -99,7 +99,7 @@ groupby.syntax.dict = {list(
     "median v3 sd v3 by id4 id5" = "DF.groupby(['id4','id5'], as_index=False, sort=False, observed=True, dropna=False).agg({'v3': ['median','std']})",
     "max v1 - min v2 by id3" = "DF.groupby('id3', as_index=False, sort=False, observed=True, dropna=False).agg({'v1':'max', 'v2':'min'}).assign(range_v1_v2=lambda x: x['v1']-x['v2'])[['id3','range_v1_v2']]",
     "largest two v3 by id6" = "DF[~DF['v3'].isna()][['id6','v3']].sort_values('v3', ascending=False).groupby('id6', as_index=False, sort=False, observed=True, dropna=False).head(2)",
-    "regression v1 v2 by id2 id4" = "DF[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: pd.Series({'r2': x.corr()['v1']['v2']**2}))",
+    "regression v1 v2 by id2 id4" = "DF[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: x['v1'].corr(x['v2'])**2).rename(columns={None: 'r2'})",
     "sum v3 count by id1:id6" = "DF.groupby(['id1','id2','id3','id4','id5','id6'], as_index=False, sort=False, observed=True, dropna=False).agg({'v3':'sum', 'v1':'size'})"
   )},
   "pydatatable" = {c(

--- a/pandas/groupby-pandas.py
+++ b/pandas/groupby-pandas.py
@@ -261,7 +261,7 @@ question = "regression v1 v2 by id2 id4" # q9
 #corr().iloc[0::2][['v2']]**2 # on 1e8,k=1e2 slower, 76s vs 47s
 gc.collect()
 t_start = timeit.default_timer()
-ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
+ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: x['v1'].corr(x['v2'])**2).rename(columns={None: "r2"})
 print(ans.shape, flush=True)
 t = timeit.default_timer() - t_start
 m = memory_usage()
@@ -272,7 +272,7 @@ write_log(task=task, data=data_name, in_rows=x.shape[0], question=question, out_
 del ans
 gc.collect()
 t_start = timeit.default_timer()
-ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
+ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: x['v1'].corr(x['v2'])**2).rename(columns={None: "r2"})
 print(ans.shape, flush=True)
 t = timeit.default_timer() - t_start
 m = memory_usage()

--- a/pandas/groupby-pandas.py
+++ b/pandas/groupby-pandas.py
@@ -261,7 +261,7 @@ question = "regression v1 v2 by id2 id4" # q9
 #corr().iloc[0::2][['v2']]**2 # on 1e8,k=1e2 slower, 76s vs 47s
 gc.collect()
 t_start = timeit.default_timer()
-ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: pd.Series({'r2': x.corr(numeric_only=True)['v1']['v2']**2}))
+ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
 print(ans.shape, flush=True)
 t = timeit.default_timer() - t_start
 m = memory_usage()
@@ -272,7 +272,7 @@ write_log(task=task, data=data_name, in_rows=x.shape[0], question=question, out_
 del ans
 gc.collect()
 t_start = timeit.default_timer()
-ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: pd.Series({'r2': x.corr(numeric_only=True)['v1']['v2']**2}))
+ans = x[['id2','id4','v1','v2']].groupby(['id2','id4'], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
 print(ans.shape, flush=True)
 t = timeit.default_timer() - t_start
 m = memory_usage()


### PR DESCRIPTION
Hello!

I was reviewing the groupby pandas benchmarks and noticed the groupby correlation benchmark could be more efficient by eliminating the Series call in `apply` and renaming the column after instead

```python
In [1]: import warnings; import pandas as pd; import numpy as np

In [2]: warnings.filterwarnings("ignore", category=FutureWarning)

In [3]: warnings.filterwarnings("ignore", category=RuntimeWarning)

In [4]: pd.__version__
Out[4]: '2.1.1'

In [5]: n = 10

In [6]: k = 10

In [7]: np.random.seed(123)

In [8]: df = pd.DataFrame({"key": np.random.randint(0, k, n), "x": np.random.rand(n), "y": np.random.rand(n)})

In [9]: df
Out[9]: 
   key         x         y
0    2  0.480932  0.531551
1    2  0.392118  0.531828
2    6  0.343178  0.634401
3    1  0.729050  0.849432
4    3  0.438572  0.724455
5    9  0.059678  0.611024
6    6  0.398044  0.722443
7    1  0.737995  0.322959
8    0  0.182492  0.361789
9    1  0.175452  0.228263

# existing benchmark
In [10]: df.groupby(["key"], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: pd.Series({'r2': x.corr(numeric_only=True)['x']['y']**2}))
Out[10]: 
   key        r2
0    2  1.000000
1    6  1.000000
2    1  0.367864
3    3       NaN
4    9       NaN
5    0       NaN

# proposed benchmark
In [11]: df.groupby(["key"], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
Out[11]: 
   key        r2
0    2  1.000000
1    6  1.000000
2    1  0.367864
3    3       NaN
4    9       NaN
5    0       NaN

In [12]: n = 10_000

In [13]: k = 100

In [14]: df = pd.DataFrame({"key": np.random.randint(0, k, n), "x": np.random.rand(n), "y": np.random.rand(n)})

# existing benchmark
In [15]: %timeit df.groupby(["key"], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: pd.Series({'r2': x.corr(numeric_only=True)['x']['y']**2}))
10.3 ms ± 27.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# proposed benchmark
In [16]: %timeit df.groupby(["key"], as_index=False, sort=False, observed=True, dropna=False).apply(lambda x: (x['x'].corr(x['y'])**2)).rename(columns={None: "r2"})
7.39 ms ± 16.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```