### PR TITLE
Update join-juliads.jl

### DIFF
--- a/juliads/join-juliads.jl
+++ b/juliads/join-juliads.jl
@@ -21,7 +21,7 @@ solution = "juliads";
 fun = "join";
 cache = true;
 on_disk = false;
-isondisk(indata) = parse(Float64, split(indata, "_")[2])>=10^9
+isondisk(indata) = false # It seems that the new machine has enough memory - parse(Float64, split(indata, "_")[2])>=10^9
 
 data_name = ENV["SRC_DATANAME"];
 src_jn_x = string("data/", data_name, ".csv");


### PR DESCRIPTION
It seems that the new benchmark machine has lots of memory and we don't need on-disk solution. **This changes the benchmarks dramatically for 10^9 data sets.**