### PR TITLE
Update name for Arrow R package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contribution and feedback are very welcome!
   - [x] [spark](https://github.com/apache/spark)
   - [x] [ClickHouse](https://github.com/yandex/ClickHouse)
   - [x] [Polars](https://github.com/ritchie46/polars)
-  - [x] [Arrow](https://github.com/apache/arrow)
+  - [x] [arrow R](https://github.com/apache/arrow)
   - [x] [DuckDB](https://github.com/duckdb/duckdb)
   - [x] [DuckDB-latest](https://github.com/duckdb/duckdb)
   - [x] [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl)

--- a/_benchplot/benchplot-dict.R
+++ b/_benchplot/benchplot-dict.R
@@ -42,7 +42,7 @@ solution.dict = {list(
   "juliads" = list(name=c(short="IMD.jl", long="InMemoryDatasets.jl"), color=c(strong="#b80000", light="#ff1f1f")),
   "clickhouse" = list(name=c(short="clickhouse", long="ClickHouse"), color=c(strong="hotpink4", light="hotpink1")),
   "polars" = list(name=c(short="polars", long="Polars"), color=c(strong="deepskyblue4", light="deepskyblue3")),
-  "arrow" = list(name=c(short="arrow", long="Arrow"), color=c(strong="aquamarine3", light="aquamarine1")),
+  "arrow" = list(name=c(short="(R)arrow", long="(R)arrow"), color=c(strong="aquamarine3", light="aquamarine1")),
   "duckdb" = list(name=c(short="duckdb", long="DuckDB"), color=c(strong="#ddcd07", light="#fff100")),
   "duckdb-latest" = list(name=c(short="duckdb-latest", long="duckdb-latest"), color=c(strong="#ddcd07", light="#fff100")),
   "datafusion" = list(name=c(short="datafusion", long="Datafusion"), color=c(strong="deepskyblue4", light="deepskyblue3"))


### PR DESCRIPTION
Hi @Tmonster, I contribute to the [Arrow R package](https://arrow.apache.org/docs/r/) and noticed Arrow's inclusion on https://duckdblabs.github.io/db-benchmark/ which is great to see.

I think a minor improvement to the way this benchmark is presented would be to make it clearer that a specific implementation of Arrow is what's being benchmarked since the name Arrow by itself generally refers to the columnar format and not any one implementation.

I've updated the README and made my best guess at changing the name in the plots since I didn't run them. Let me know if that looks like it'll do the trick. For the changed name for the plots, I opted to follow the style you're already using with (py)data.table but feel free to suggest something else. We generally refer to the Arrow R package as "R arrow" or "arrow R" so any string which contains those would be good.