### PR TITLE
Lower timeout thresholds

### DIFF
--- a/_control/timeout.csv
+++ b/_control/timeout.csv
@@ -1,10 +1,10 @@
 task,in_rows,minutes
-groupby,1e7,60
-groupby,1e8,120
-groupby,1e9,180
-join,1e7,120
-join,1e8,240
-join,1e9,240
+groupby,1e7,10
+groupby,1e8,30
+groupby,1e9,60
+join,1e7,10
+join,1e8,30
+join,1e9,60
 groupby2014,1e7,60
 groupby2014,1e8,120
 groupby2014,1e9,180


### PR DESCRIPTION
lowering timeout thresholds for all queries. most solutions can finish within the time limit for the smaller scale factors, but on the larger ones, I don't like waiting 6 hours only for a timeout to be reached