### PR TITLE
remove pydatatable from running

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,7 +17,7 @@ jobs:
   strategy:
     fail-fast: false
     matrix:
-      solution: [data.table, collapse, dplyr, pandas, pydatatable, spark, juliadf, juliads, polars, R-arrow, duckdb, datafusion, dask, clickhouse]
+      solution: [data.table, collapse, dplyr, pandas, spark, juliadf, juliads, polars, R-arrow, duckdb, datafusion, dask, clickhouse]
   name: Solo solutions
   runs-on: ubuntu-latest
   env:

--- a/_control/solutions.csv
+++ b/_control/solutions.csv
@@ -11,8 +11,6 @@ dplyr,groupby2014
 pandas,groupby
 pandas,join
 pandas,groupby2014
-pydatatable,groupby
-pydatatable,join
 spark,groupby
 spark,join
 dask,groupby


### PR DESCRIPTION
Pretty sure pydatatable is the library here https://github.com/h2oai/datatable, which hasn't been updated in over 1.5 years, with the last commit being 6 months ago. It consistently fails CI, so removing it from CI and future runs. Previous data/code will remain. 